### PR TITLE
Update to 0.6.3

### DIFF
--- a/Train/custom_api.py
+++ b/Train/custom_api.py
@@ -153,4 +153,4 @@ def upsample(inputs, r=4, **kwargs):
   return res
 
 
-scale=upsample
+scale = upsample

--- a/VSR/Framework/Callbacks.py
+++ b/VSR/Framework/Callbacks.py
@@ -31,6 +31,7 @@ def _save_model_predicted_images(output, index, mode, cols=1, **kwargs):
   save_dir = kwargs.get('save_dir') or '.'
   sub_dir = kwargs.get('subdir') or '.'
   names = kwargs.get('name', [('image', 0, 0)])
+  suffix = kwargs.get('suffix')
   img = output[index] if isinstance(output, list) else output
   img = _to_normalized_image(img, mode)
   if len(img) != len(names):
@@ -54,11 +55,19 @@ def _save_model_predicted_images(output, index, mode, cols=1, **kwargs):
     frames = int(frames)
     rep = 0
     if frames > 1:
-      path_1 = path / '{}/{:04d}_PR_{:04d}.png'.format(name, seq, rep)
+      if suffix:
+        path_1 = path / '{}/{:04d}_PR_{:04d}.png'.format(name, seq, rep)
+      else:
+        path_1 = path / '{}/{:04d}.png'.format(name, seq)
     else:
-      path_1 = path / '{}_PR_{:04d}.png'.format(name, rep)
+      if suffix:
+        path_1 = path / '{}_PR_{:04d}.png'.format(name, rep)
+      else:
+        path_1 = path / '{}.png'.format(name)
     path_1.parent.mkdir(parents=True, exist_ok=True)
     while path_1.exists():
+      if not suffix:
+        break
       rep += 1
       if frames > 1:
         path_1 = path / '{}/{:04d}_PR_{:04d}.png'.format(name, seq, rep)
@@ -235,9 +244,9 @@ def _image_align(image, scale, **kwargs):
   return image[..., :h, :w, :]
 
 
-def save_image(save_dir='.', output_index=-1, **kwargs):
+def save_image(save_dir='.', output_index=-1, suffix=True, **kwargs):
   return partial(_save_model_predicted_images, save_dir=save_dir,
-                 index=output_index, **kwargs)
+                 index=output_index, suffix=suffix, **kwargs)
 
 
 def save_batch_image(save_dir='.', output_index=-1, cols=8, **kwargs):

--- a/VSR/Tools/DataProcessing/NTIRE19RSR.py
+++ b/VSR/Tools/DataProcessing/NTIRE19RSR.py
@@ -1,0 +1,107 @@
+#  Copyright (c): Wenyi Tang 2017-2019.
+#  Author: Wenyi Tang
+#  Email: wenyi.tang@intel.com
+#  Update Date: 2019 - 1 - 22
+
+
+from pathlib import Path
+import tqdm
+import numpy as np
+import tensorflow as tf
+from PIL import Image
+
+from VSR.Util.ImageProcess import array_to_img, img_to_array
+
+tf.flags.DEFINE_string("trainlr", None, "Path to train LR Data.")
+tf.flags.DEFINE_string("trainhr", None, "Path to train HR Data.")
+tf.flags.DEFINE_string("validation", None, "Path to validation LR.")
+tf.flags.DEFINE_string("results", None, "Path to results' png.")
+tf.flags.DEFINE_string("save_dir", None, "Output directory.")
+tf.flags.DEFINE_integer("patch_size", 128, "Cropped patch size.")
+tf.flags.DEFINE_integer("stride", 128, "Cropped patch stride.")
+tf.flags.DEFINE_integer("scale", 1, "Resize lr images.")
+
+FLAGS = tf.flags.FLAGS
+
+
+def divide(img: Image, stride: int, size: int) -> list:
+  w = img.width
+  h = img.height
+  img = img_to_array(img)
+  patches = []
+  img = np.pad(img, [[0, size - h % stride or stride],
+                     [0, size - w % stride or stride], [0, 0]],
+               mode='reflect')
+  size - w % stride
+  for i in np.arange(0, h, stride):
+    for j in np.arange(0, w, stride):
+      patches.append(img[i:i + size, j:j + size])
+  return patches
+
+
+def combine(ref: Image, sub: list, stride) -> Image:
+  w = ref.width
+  h = ref.height
+  blank = np.zeros([h, w, 3], 'float32')
+  count = np.zeros([h, w, 1])
+  k = 0
+  for i in np.arange(0, h, stride):
+    for j in np.arange(0, w, stride):
+      p = sub[k]
+      k += 1
+      try:
+        blank[i:i + p.height, j:j + p.width] += img_to_array(p)
+      except ValueError:
+        blank[i:i + p.height, j:j + p.width] += img_to_array(p)[:h - i, :w - j]
+      count[i:i + p.height, j:j + p.width] += 1
+  blank /= count
+  return array_to_img(blank, 'RGB')
+
+
+def rsr():
+  save_dir = Path(FLAGS.save_dir)
+  save_dir.mkdir(exist_ok=True, parents=True)
+  if FLAGS.trainlr:
+    files = sorted(Path(FLAGS.trainlr).glob("*.png"))
+    if FLAGS.results:
+      print(" [!] Combining...\n")
+      results = Path(FLAGS.results)
+      for f in tqdm.tqdm(files, ascii=True):
+        sub = list(results.glob("{}_????.png".format(f.stem)))
+        sub.sort(key=lambda x: int(x.stem[-4:]))
+        sub = [Image.open(s) for s in sub]
+        img = combine(Image.open(f), sub, FLAGS.stride)
+        img.save("{}/{}_sr.png".format(save_dir, f.stem))
+    else:
+      print(" [!] Dividing...\n")
+      for f in tqdm.tqdm(files, ascii=True):
+        pf = divide(Image.open(f), FLAGS.stride, FLAGS.patch_size)
+        for i, p in enumerate(pf):
+          array_to_img(p, 'RGB').save(
+            "{}/{}_{:04d}.png".format(save_dir, f.stem, i))
+  if FLAGS.validation:
+    files = sorted(Path(FLAGS.validation).glob("*.png"))
+    if FLAGS.results:
+      results = Path(FLAGS.results)
+      print(" [!] Combining...\n")
+      for f in tqdm.tqdm(files, ascii=True):
+        sub = list(results.glob("{}_????.png".format(f.stem)))
+        sub.sort(key=lambda x: int(x.stem[-4:]))
+        sub = [Image.open(s) for s in sub]
+        img = combine(Image.open(f), sub, FLAGS.stride)
+        img.save("{}/{}_sr.png".format(save_dir, f.stem))
+    else:
+      print(" [!] Dividing...\n")
+      for f in tqdm.tqdm(files, ascii=True):
+        pf = divide(Image.open(f), FLAGS.stride, FLAGS.patch_size)
+        for i, p in enumerate(pf):
+          array_to_img(p, 'RGB').save(
+            "{}/{}_{:04d}.png".format(save_dir, f.stem, i))
+
+
+def main(*args, **kwargs):
+  rsr()
+
+
+if __name__ == '__main__':
+  tf.app.run(main)

--- a/VSR/Tools/Run.py
+++ b/VSR/Tools/Run.py
@@ -23,7 +23,7 @@ tf.flags.DEFINE_enum('model', None, list_supported_models(),
 tf.flags.DEFINE_enum('output_color', 'RGB', ('RGB', 'L', 'GRAY', 'Y'),
                      help="specify output color format")
 tf.flags.DEFINE_enum('train_data_crop', 'random', ('random', 'stride'),
-                      help="how to crop training data")
+                     help="how to crop training data")
 tf.flags.DEFINE_integer('epochs', 50, lower_bound=1, help="training epochs")
 tf.flags.DEFINE_integer('steps_per_epoch', 200, lower_bound=1,
                         help="specify steps in every epoch training")
@@ -41,7 +41,7 @@ tf.flags.DEFINE_string('test', None, help="specify another dataset for testing")
 tf.flags.DEFINE_string('infer', None,
                        help="specify a file, a path or a dataset for inferring")
 tf.flags.DEFINE_string('save_dir', '../Results',
-                       help="specify a folder to save checkpoint and output images")
+                       "specify a folder to save checkpoint and output images")
 tf.flags.DEFINE_string('data_config', '../Data/datasets.yaml',
                        help="path to data config file")
 tf.flags.DEFINE_string('dataset', 'none',
@@ -60,6 +60,8 @@ tf.flags.DEFINE_bool('export', False, help="whether to export tf model")
 tf.flags.DEFINE_bool('freeze', False,
                      help="whether to export freeze model, "
                           "ignored if export is False")
+tf.flags.DEFINE_bool('auto_rename', True,
+                     "Add a suffix and auto rename the conflict output file.")
 tf.flags.DEFINE_bool('v', False, help="show verbose info")
 
 
@@ -141,8 +143,10 @@ def init_loader_config(opt):
       benchmark_config.output_callbacks += [functor]
       infer_config.output_callbacks += [functor]
   # Add image saver at last.
-  benchmark_config.output_callbacks += [save_image(opt.root, opt.output_index)]
-  infer_config.output_callbacks += [save_image(opt.root, opt.output_index)]
+  benchmark_config.output_callbacks += [
+    save_image(opt.root, opt.output_index, opt.auto_rename)]
+  infer_config.output_callbacks += [
+    save_image(opt.root, opt.output_index, opt.auto_rename)]
   if opt.lr_decay:
     train_config.lr_schedule = lr_decay(lr=opt.lr, **opt.lr_decay)
   # modcrop: A boolean to specify whether to crop the edge of images to be

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-VERSION = '0.6.2'
+VERSION = '0.6.3'
 
 REQUIRED_PACKAGES = [
   'numpy',


### PR DESCRIPTION
## Changelog 0.6.3

- [ADD] Several tools for NTIRE 2019 competitions :).
- [ADD] Several options for **run.py**:
      `--auto_rename` ([Default: True]) to toggle suffix to output files.
      `-f`, `-f2`, `-f3` to add custom callbacks to feature, label, output.
      `--train_data_crop` to specify crop method to training data. ("random" or "stride")
      `--val_num` to specify validation steps.
      `--infer` now can pass glob patterns. (E.g `--infer=test/*.png`)
- [ADD] custom api **blur**

- [FIX] eval mode bug when use `--test`.
- [FIX] prepare_data.py can use `--noauth_local_webserver` correctly.